### PR TITLE
handle case where player submit a name with non ASCII characters

### DIFF
--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -27,7 +27,7 @@ Then /^the scores should be:$/ do |table|
   end
 end
 
-Then /^the log for (\w+) should show:$/ do |player_name, table|
+Then /^the log for (.+) should show:$/ do |player_name, table|
   player = players.find{ |p| p.name == player_name }
   visit player.personal_page
   actual = page.all('li').map do |li|

--- a/features/warm_up.feature
+++ b/features/warm_up.feature
@@ -17,3 +17,18 @@ Feature: Warm up
        | bob      | 10    |
      And the log for bob should show:
        | result: correct | points awarded: 10 |
+
+  Scenario:
+    Given a player "Sébastian" who plays like this:
+      """
+      get '/' do
+        'Sébastian'
+      end
+      """
+    When the player is entered
+    And the game is played for 1 second
+    Then the scores should be:
+      | player    | score |
+      | Sébastian | 10    |
+    And the log for Sébastian should show:
+      | result: correct | points awarded: 10 |

--- a/lib/extreme_startup/question_factory.rb
+++ b/lib/extreme_startup/question_factory.rb
@@ -69,7 +69,7 @@ module ExtremeStartup
     end
 
     def answer=(answer)
-      @answer = answer
+      @answer = answer.force_encoding("UTF-8")
     end
 
     def answer

--- a/spec/extreme_startup/warmup_question_spec.rb
+++ b/spec/extreme_startup/warmup_question_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'extreme_startup/player'
+
+module ExtremeStartup
+  describe Question do
+    let(:player) { Player.new({"name" => "S\u00E9bastian".force_encoding("UTF-8"),
+                               "url" => "http://127.0.0.1:8080", }) }
+    let(:question) {
+      question = WarmupQuestion.new(player)
+      question.answer = "S\u00E9bastian".force_encoding("ASCII-8BIT")
+      question
+    }
+
+    context "when displaying response with an answer encoded into ASCII-8BIT" do
+      it "should not raise error" do
+        lambda { "For player #{:player}\n#{question.display_result}" }.should_not raise_error
+      end
+    end
+
+  end
+end
+


### PR DESCRIPTION
When I submit into the game with name `Sébastian`, then at first question server shut down with given error :

```
GET: http://127.0.0.1:8080?q=7c528a60:%20what%20is%20your%20name
lib/extreme_startup/quiz_master.rb:93:in `start': incompatible character encodings: UTF-8 and ASCII-8BIT (Encoding::CompatibilityError)
    from lib/extreme_startup/web_server.rb:133:in `block (2 levels) in <class:WebServer>'
```

After investigation, it appears that player's name readen from HTTP params in Sinatra class is `UTF-8` in this case.
Furthermore answer retrieved by HTTParty.get(url) and converted by `.to_s()` is `ASCII-8BIT` encoded.
Now concatenating an `UTF-8` encoded string with an `ASCII-8BIT` encoded string is considered not safer by Ruby.

I propose to force each answer to be UTF-8 encoded in order to solve this issue.
