### PR TITLE
client with another ip than one from player url can't withdraw

### DIFF
--- a/features/step_definitions/team_steps.rb
+++ b/features/step_definitions/team_steps.rb
@@ -43,8 +43,23 @@ end
 
 When /^I withdraw$/ do
   player_uuid = app.players.keys.first
+  original_headers = page.driver.options[:headers]
+  page.driver.options[:headers] = {'REMOTE_ADDR' => "deathstar.local"}
   visit "/players/#{player_uuid}"
   click_link 'Withdraw'
+  page.driver.options[:headers] = original_headers
+end
+
+When /^someone else wants to withdraw for me$/ do
+  original_headers = page.driver.options[:headers]
+  page.driver.options[:headers] = {'REMOTE_ADDR' => "tatooine.local"}
+  player_uuid = app.players.keys.first
+  visit "/players/#{player_uuid}"
+  page.driver.options[:headers] = original_headers
+end
+
+Then /^it is impossible to withdraw$/ do
+  page.should_not have_link "Withdraw"
 end
 
 Then /^my name should not be on the leaderboard anymore$/ do

--- a/features/withdraw.feature
+++ b/features/withdraw.feature
@@ -9,3 +9,8 @@ Feature: A team can withdraw from the game
     Then my name should not be on the leaderboard anymore
     And my player page should give a nice error
     And the game master should not send me anymore questions
+
+  Scenario: Someone else can't withdraw for me
+    Given I am playing
+    When someone else wants to withdraw for me
+    Then it is impossible to withdraw

--- a/lib/extreme_startup/player.rb
+++ b/lib/extreme_startup/player.rb
@@ -39,5 +39,9 @@ module ExtremeStartup
     def to_s
       "#{name} (#{url})"
     end
+
+    def can_withdraw(ip)
+      @url.include? ip
+    end
   end
 end

--- a/public/js/leaderboard.js
+++ b/public/js/leaderboard.js
@@ -39,7 +39,7 @@ $(document).ready(function() {
 						$('<li/>', {class: "player"})
 						.append($('<div>' + entry.playername + '</div>').addClass("ranking name").css("background-color", colourTable[entry.playerid]))
 						.append($('<div>' + entry.score + '</div>').addClass("ranking points").css("background-color", colourTable[entry.playerid]))
-						.append($('<a>Withdraw</a>').attr("href", "/withdraw/" + entry.playerid))));
+						.append(entry.can_withdraw ? $('<a>Withdraw</a>').attr("href", "/withdraw/" + entry.playerid) : '')));
 				}
 				$("#scoreboard").replaceWith(list); 
 			}

--- a/views/personal_page.haml
+++ b/views/personal_page.haml
@@ -10,8 +10,9 @@
       Your score is:
       %span.score #{score}
 
-    %a{ :href => "/withdraw/#{playerid}" }
-      Withdraw
+    - if can_withdraw
+      %a{ :href => "/withdraw/#{playerid}" }
+        Withdraw
 
     %h2 Log:
     %ul


### PR DESCRIPTION
During [a big session](http://blog.xebia.fr/wp-content/uploads/2012/07/session.png), one have withdraw the best team - maybe by mistake or not.

This pull request hide withdraw link to everyone else than player. You are a player if it's url contains your browser ip.
