### PR TITLE
String as return

### DIFF
--- a/lib/extreme_startup/web_server.rb
+++ b/lib/extreme_startup/web_server.rb
@@ -133,7 +133,7 @@ module ExtremeStartup
     end
     
     post '/advance_round' do
-      question_factory.advance_round
+      question_factory.advance_round.to_s
     end
  
     post '/pause' do


### PR DESCRIPTION
If the route return code is an int, sinatra use it as http status code
