### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ bundle exec ruby web_server.rb
 * Or the docker way
 
 ````
-#The first time
+# The first time
 docker build -t extreme_startup .
 docker run -p 3000:3000 extreme_startup
 ````


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
