### PR TITLE
Accept EADDRNOTAVAIL for bogus test player URL

### DIFF
--- a/features/support/testing_api.rb
+++ b/features/support/testing_api.rb
@@ -36,7 +36,7 @@ module TestingApi
     def responsive?
       response = Net::HTTP.start('localhost', @port) { |http| http.get('/ping') }
       response.body == 'OK'
-    rescue Errno::ECONNREFUSED, Errno::EBADF
+    rescue Errno::ECONNREFUSED, Errno::EBADF, Errno::EADDRNOTAVAIL
       false
     end
 


### PR DESCRIPTION
Seems that when running the tests in the Docker container we get a different error message.