### PR TITLE
Fixes an issue when running the "warmup".

### DIFF
--- a/lib/extreme_startup/question_factory.rb
+++ b/lib/extreme_startup/question_factory.rb
@@ -437,7 +437,7 @@ module ExtremeStartup
     end
   end
 
-  class WarmupQuestionFactory
+  class WarmupQuestionFactory < QuestionFactory
     def next_question(player)
       WarmupQuestion.new(player)
     end


### PR DESCRIPTION
Without this fix, when I tried to run the "warmup" using:

docker run -p 80:3000 -e WARMUP=1 extreme_startup

When I go to http://127.0.0.1/controlpanel I see:

Internal server error

and there is a stack trace:

NoMethodError - undefined method `round' for #<ExtremeStartup::WarmupQuestionFactory:0x00000000d9fb48>:
 /usr/src/app/lib/extreme_startup/web_server.rb:79:in `block in <class:WebServer>'
 /usr/local/bundle/gems/sinatra-1.2.6/lib/sinatra/base.rb:1152:in `call'
 /usr/local/bundle/gems/sinatra-1.2.6/lib/sinatra/base.rb:1152:in `block in compile!'
 ...

 I don't know how to write a test for this, so here is the fix without an automated test.